### PR TITLE
Closes #56

### DIFF
--- a/app/src/main/java/com/microsoft/o365_android_onenote_rest/SignInActivity.java
+++ b/app/src/main/java/com/microsoft/o365_android_onenote_rest/SignInActivity.java
@@ -118,6 +118,11 @@ public class SignInActivity
     @Override
     public void onError(Exception e) {
         e.printStackTrace();
+        String msg;
+        if (null == (msg = e.getLocalizedMessage())) {
+            msg = getString(R.string.signin_err);
+        }
+        Toast.makeText(this, msg, Toast.LENGTH_SHORT).show();
     }
 
     @Override

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,4 +33,5 @@
     <string name="err_setup_msg">This snippet requires a notebook, section, group, or page before it will run. For example if you are deleting a page, you must first have a page to delete. Check that the appropriate item exists before running this snippet.</string>
     <string name="et_hint">&lt;Your text here&gt;</string>
     <string name="warning_clientid_redirecturi_incorrect">The client ID or redirect URI is not valid. Enter a valid client ID and redirect URI in the ServiceConstants.java file and run again</string>
+    <string name="signin_err">An error signing in has occurred. Check LogCat for details.</string>
 </resources>


### PR DESCRIPTION
This commit inspects the ```Exception``` passed to ```onError()```

If there's a message: it's toasted. 
If there's no message: general error is toasted and the user is prompted to inspect LogCat for the details of the error.